### PR TITLE
5 no permission node for c

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 This mod allows all players to use `/c` to switch to spectator mode, using the command again will return the player to 
 the position they switched from.
 
+# Permissions
+By default, the command is available for all players you can this via the `survival-spectator.c` permissions node.
+
 # Requirements
 - Fabric
 - Fabric API

--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,9 @@ dependencies {
 	// Cardinal Components
 	modImplementation "org.ladysnake.cardinal-components-api:cardinal-components-base:${project.cca_version}"
 	modImplementation "org.ladysnake.cardinal-components-api:cardinal-components-entity:${project.cca_version}"
+
+	// Permissions
+	include(modImplementation("me.lucko:fabric-permissions-api:${project.fabric_permissions_version}"))
 }
 
 processResources {

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,7 @@ loader_version=0.16.14
 loom_version=1.11-SNAPSHOT
 
 # Mod Properties
-mod_version=1.0.3
+mod_version=1.1.0
 maven_group=com.njackal
 archives_base_name=survival-spectator
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,3 +17,4 @@ archives_base_name=survival-spectator
 # Dependencies
 fabric_version=0.129.0+1.21.7
 cca_version=7.0.0-beta.1
+fabric_permissions_version=0.4.1

--- a/src/main/java/com/njackal/SurvivalSpectator.java
+++ b/src/main/java/com/njackal/SurvivalSpectator.java
@@ -1,6 +1,7 @@
 package com.njackal;
 
 import com.mojang.brigadier.context.CommandContext;
+import me.lucko.fabric.api.permissions.v0.Permissions;
 import net.fabricmc.api.ModInitializer;
 
 import net.fabricmc.fabric.api.command.v2.CommandRegistrationCallback;
@@ -26,6 +27,8 @@ public class SurvivalSpectator implements ModInitializer {
 	// That way, it's clear which mod wrote info, warnings, and errors.
     public static final Logger LOGGER = LoggerFactory.getLogger("modid");
 
+	public static final String PERM_C = "survival-spectator.c";
+
 	@Override
 	public void onInitialize() {
 		// This code runs as soon as Minecraft is in a mod-load-ready state.
@@ -39,7 +42,22 @@ public class SurvivalSpectator implements ModInitializer {
 	private void commandInit() {
 		LOGGER.info("Initializing Commands");
 
-		CommandRegistrationCallback.EVENT.register(((dispatcher, registryAccess, environment) -> dispatcher.register(literal("c").executes(this::onCCommand))));
+		CommandRegistrationCallback.EVENT.register((
+				(dispatcher, registryAccess, environment) ->
+						dispatcher.register(
+								literal("c")
+										.requires(ServerCommandSource::isExecutedByPlayer)
+										.requires(source -> {
+											if (source.getServer().isDedicated()){ //multiplayer
+												return Permissions.check(source,PERM_C, 0);
+											} else {//singleplayer
+												return true;
+											}
+										})
+										.executes(this::onCCommand)
+						)
+				)
+		);
 	}
 
 	private int onCCommand(CommandContext<ServerCommandSource> context) {

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -36,7 +36,9 @@
 		"fabricloader": ">=0.15.11",
 		"minecraft": "~1.21",
 		"java": ">=21",
-		"fabric-api": "*"
+		"fabric-api": "*",
+		"cardinal-components-base": ">=7.0.0-beta.1",
+		"cardinal-components-entity": ">=7.0.0-beta.1"
 	},
 	"suggests": {
 	},


### PR DESCRIPTION
closes #5 
adds proper dependency for CCA so the #4 crash wont happen (and fabric will properly warn users they are missing CCA)